### PR TITLE
Querying enabled feature toggles for current user

### DIFF
--- a/HiP-FeatureToggle/Controllers/FeatureGroupsController.cs
+++ b/HiP-FeatureToggle/Controllers/FeatureGroupsController.cs
@@ -156,7 +156,8 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Controllers
             }
             catch (InvalidOperationException e)
             {
-                return StatusCode(409, e.Message); // tried to rename protected group
+                // tried to rename protected group or tried to move users to the public group
+                return StatusCode(409, e.Message);
             }
             catch (ArgumentException e)
             {
@@ -172,6 +173,7 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Controllers
         [ProducesResponseType(200)]
         [ProducesResponseType(403)]
         [ProducesResponseType(404)]
+        [ProducesResponseType(409)]
         public IActionResult AssignMember(string userId, int groupId)
         {
             if (!IsAdministrator)
@@ -184,6 +186,10 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Controllers
             catch (ResourceNotFoundException<FeatureGroup> e)
             {
                 return NotFound(e.Message);
+            }
+            catch (InvalidOperationException e)
+            {
+                return StatusCode(409, e.Message); // tried to move user to public group
             }
             return Ok();
         }

--- a/HiP-FeatureToggle/Controllers/FeatureGroupsController.cs
+++ b/HiP-FeatureToggle/Controllers/FeatureGroupsController.cs
@@ -40,7 +40,7 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Controllers
             if (!IsAdministrator)
                 return Forbid();
 
-            var groups = _manager.GetGroups(loadMembers: true, loadFeatures: true);
+            var groups = _manager.GetAllGroups(loadMembers: true, loadFeatures: true);
             var results = groups.ToList().Select(g => new FeatureGroupResult(g)); // note: ToList() is required here
             return Ok(results);
         }

--- a/HiP-FeatureToggle/CustomSwaggerOperationFilter.cs
+++ b/HiP-FeatureToggle/CustomSwaggerOperationFilter.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.AspNetCore.Mvc.Authorization;
+using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PaderbornUniversity.SILab.Hip.FeatureToggle
+{
+    /// <summary>
+    /// This is a modified version of <see cref="Webservice.SwaggerOperationFilter"/> which behaves as follows:
+    /// - if authorization is required, a required access token field is inserted
+    /// - if authorization is optional (i.e. [AllowAnonymous] attribute is present), an optional access token field
+    ///   is inserted (THIS is the modification. In the original version, no access token field is inserted)
+    /// - if authorization is not required at all, no access token field is inserted
+    /// 
+    /// This class should be removed once the modification is approved for the original class.
+    /// </summary>
+    public class CustomSwaggerOperationFilter : IOperationFilter
+    {
+        public void Apply(Operation operation, OperationFilterContext context)
+        {
+            var filterPipeline = context.ApiDescription.ActionDescriptor.FilterDescriptors;
+            var isAuthorized = filterPipeline.Select(filterInfo => filterInfo.Filter).Any(filter => filter is AuthorizeFilter);
+            var allowAnonymous = filterPipeline.Select(filterInfo => filterInfo.Filter).Any(filter => filter is IAllowAnonymousFilter);
+
+            if (!isAuthorized)
+                return;
+
+            if (operation.Parameters == null)
+                operation.Parameters = new List<IParameter>();
+
+            operation.Parameters.Add(new NonBodyParameter
+            {
+                Name = "Authorization",
+                In = "header",
+                Description = "access token",
+                Required = !allowAnonymous,
+                Type = "string"
+            });
+
+            operation.Responses.Add("401", new Response { Description = "Unauthorized" });
+        }
+
+    }
+}

--- a/HiP-FeatureToggle/CustomSwaggerOperationFilter.cs
+++ b/HiP-FeatureToggle/CustomSwaggerOperationFilter.cs
@@ -38,7 +38,8 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle
                 Type = "string"
             });
 
-            operation.Responses.Add("401", new Response { Description = "Unauthorized" });
+            if (!allowAnonymous)
+                operation.Responses.Add("401", new Response { Description = "Unauthorized" });
         }
 
     }

--- a/HiP-FeatureToggle/Managers/FeatureGroupsManager.cs
+++ b/HiP-FeatureToggle/Managers/FeatureGroupsManager.cs
@@ -77,7 +77,7 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
         /// <exception cref="ArgumentException">The new group name is already in use</exception>
         /// <exception cref="ResourceNotFoundException{Feature}">There is no feature with the specified ID</exception>
         /// <exception cref="ResourceNotFoundException{FeatureGroup}">There is no group with the specified ID</exception>
-        /// <exception cref="InvalidOperationException">It is attempted to rename a protected feature group</exception>
+        /// <exception cref="InvalidOperationException">Tried to rename a protected feature group or tried to move users to the public group</exception>
         public void UpdateGroup(int groupId, FeatureGroupArgs args)
         {
             if (args == null)
@@ -93,6 +93,9 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
 
             if (group.IsProtected && args.Name != group.Name)
                 throw new InvalidOperationException($"Protected group '{group.Name}' cannot be renamed");
+
+            if (group.Id == PublicGroup.Id && args.Members.Count > 0)
+                throw new InvalidOperationException("Users cannot explicitly be moved into the public group");
 
             group.Name = args.Name;
             var newMembers = GetOrCreateUsers(args.Members).ToList();
@@ -126,8 +129,12 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
         }
 
         /// <exception cref="ResourceNotFoundException{FeatureGroup}">The group with specified ID does not exist</exception>
+        /// <exception cref="InvalidOperationException">Tried to move user to the public group</exception>
         public void MoveUserToGroup(string userId, int groupId)
         {
+            if (groupId == PublicGroup.Id)
+                throw new InvalidOperationException("Users cannot explicitly be moved into the public group");
+
             var user = GetOrCreateUser(userId);
             var group = GetGroup(groupId, loadMembers: true);
 

--- a/HiP-FeatureToggle/Managers/FeatureGroupsManager.cs
+++ b/HiP-FeatureToggle/Managers/FeatureGroupsManager.cs
@@ -94,7 +94,7 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
             if (group.IsProtected && args.Name != group.Name)
                 throw new InvalidOperationException($"Protected group '{group.Name}' cannot be renamed");
 
-            if (group.Id == PublicGroup.Id && args.Members.Count > 0)
+            if (group.Id == PublicGroup.Id && (args.Members?.Count ?? 0) > 0)
                 throw new InvalidOperationException("Users cannot explicitly be moved into the public group");
 
             group.Name = args.Name;

--- a/HiP-FeatureToggle/Managers/FeatureGroupsManager.cs
+++ b/HiP-FeatureToggle/Managers/FeatureGroupsManager.cs
@@ -1,9 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore;
-using PaderbornUniversity.SILab.Hip.FeatureToggle.Data;
+﻿using PaderbornUniversity.SILab.Hip.FeatureToggle.Data;
 using PaderbornUniversity.SILab.Hip.FeatureToggle.Models.Entity;
 using PaderbornUniversity.SILab.Hip.FeatureToggle.Models.Rest;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
@@ -14,99 +12,10 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
     /// <remarks>
     /// There exists a default feature group new users are assigned to.
     /// </remarks>
-    public class FeatureGroupsManager
+    public class FeatureGroupsManager : FeatureTogglesManagerBase
     {
-        private static readonly User[] _noUsers = new User[0];
-        private static readonly Feature[] _noFeatures = new Feature[0];
-
-        private readonly ToggleDbContext _db;
-
-        /// <summary>
-        /// The default group for authorized users.
-        /// </summary>
-        public FeatureGroup DefaultGroup { get; }
-
-        /// <summary>
-        /// The group for unauthorized users.
-        /// </summary>
-        public FeatureGroup PublicGroup { get; }
-
-        public FeatureGroupsManager(ToggleDbContext db)
+        public FeatureGroupsManager(ToggleDbContext db) : base(db)
         {
-            _db = db;
-
-            // Load standard groups which are always available and can't be deleted.
-            // If this fails, the database is not correctly initialized.
-            DefaultGroup = GetGroups(true, true).Single(g => g.Name == FeatureGroup.DefaultGroupName);
-            PublicGroup = GetGroups(true, true).Single(g => g.Name == FeatureGroup.PublicGroupName);
-        }
-
-        public User GetOrCreateUser(string userId)
-        {
-            var user = _db.Users
-                .Include(nameof(User.FeatureGroup))
-                .FirstOrDefault(u => u.Id == userId);
-
-            if (user != null)
-                return user;
-
-            // create new user
-            var newUser = CreateUser(userId);
-            _db.SaveChanges();
-            return newUser;
-        }
-
-        public IEnumerable<User> GetOrCreateUsers(IEnumerable<string> userIds)
-        {
-            if (userIds == null)
-                return _noUsers;
-
-            var userIdsSet = userIds.ToSet();
-            var storedUsers = _db.Users.Where(u => userIdsSet.Contains(u.Id)).ToList();
-            var missingUserIds = userIdsSet.Except(storedUsers.Select(u => u.Id));
-
-            if (missingUserIds.Any())
-            {
-                // Create missing users
-                var newUsers = missingUserIds.Select(id => CreateUser(id)).ToList();
-                _db.SaveChanges();
-                return storedUsers.Concat(newUsers);
-            }
-
-            return storedUsers;
-        }
-
-        /// <exception cref="ResourceNotFoundException{Feature}">No features exist for one or multiple of the specified IDs</exception>
-        public IReadOnlyCollection<Feature> GetFeatures(IEnumerable<int> featureIds, bool loadGroups = false)
-        {
-            if (featureIds == null)
-                return _noFeatures;
-
-            var featureIdsSet = featureIds.ToSet();
-
-            var storedFeatures = _db.Features
-                .IncludeIf(loadGroups, nameof(Feature.GroupsWhereEnabled))
-                .Where(f => featureIdsSet.Contains(f.Id)).ToList();
-
-            var missingFeatureIds = featureIdsSet.Except(storedFeatures.Select(f => f.Id));
-
-            if (missingFeatureIds.Any())
-                throw new ResourceNotFoundException<Feature>(missingFeatureIds);
-
-            return storedFeatures;
-        }
-
-        public IQueryable<FeatureGroup> GetGroups(bool loadMembers = false, bool loadFeatures = false)
-        {
-            return _db.FeatureGroups
-                .IncludeIf(loadMembers, nameof(FeatureGroup.Members))
-                .IncludeIf(loadFeatures, nameof(FeatureGroup.EnabledFeatures));
-        }
-
-        public FeatureGroup GetGroup(int groupId, bool loadMembers = false, bool loadFeatures = false)
-        {
-            return GetGroups(loadMembers, loadFeatures)
-                .FirstOrDefault(g => g.Id == groupId);
         }
 
         /// <exception cref="ArgumentNullException">Specified argument is null</exception>
@@ -123,8 +32,8 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
             var group = new FeatureGroup { Name = args.Name };
 
             group.EnabledFeatures = GetFeatures(args.EnabledFeatures)
-                    .Select(f => new FeatureToFeatureGroupMapping(f, group))
-                    .ToList();
+                .Select(f => new FeatureToFeatureGroupMapping(f, group))
+                .ToList();
 
             group.Members = GetOrCreateUsers(args.Members).ToList();
 
@@ -235,18 +144,6 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
             user.FeatureGroup.Members.Remove(user);
             group.Members.Add(user);
             user.FeatureGroup = group;
-        }
-
-        private User CreateUser(string id)
-        {
-            var user = new User
-            {
-                Id = id,
-                FeatureGroup = DefaultGroup
-            };
-
-            _db.Users.Add(user);
-            return user;
         }
     }
 }

--- a/HiP-FeatureToggle/Managers/FeatureTogglesManagerBase.cs
+++ b/HiP-FeatureToggle/Managers/FeatureTogglesManagerBase.cs
@@ -1,0 +1,135 @@
+﻿using Microsoft.EntityFrameworkCore;
+using PaderbornUniversity.SILab.Hip.FeatureToggle.Data;
+using PaderbornUniversity.SILab.Hip.FeatureToggle.Models.Entity;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
+{
+    public abstract class FeatureTogglesManagerBase
+    {
+        private static readonly User[] _noUsers = new User[0];
+        private static readonly Feature[] _noFeatures = new Feature[0];
+
+        protected readonly ToggleDbContext _db;
+
+        /// <summary>
+        /// The default group for authorized users.
+        /// </summary>
+        public FeatureGroup DefaultGroup { get; }
+
+        /// <summary>
+        /// The group for unauthorized users.
+        /// </summary>
+        public FeatureGroup PublicGroup { get; }
+
+        public FeatureTogglesManagerBase(ToggleDbContext db)
+        {
+            _db = db;
+
+            // Load standard groups which are always available and can't be deleted.
+            // If this fails, the database is not correctly initialized.
+            DefaultGroup = GetAllGroups(true, true)
+                .Include(g => g.EnabledFeatures).ThenInclude(m => m.Feature)
+                .Single(g => g.Name == FeatureGroup.DefaultGroupName);
+
+            PublicGroup = GetAllGroups(true, true)
+                .Include(g => g.EnabledFeatures).ThenInclude(m => m.Feature) // loading this is required for checking effectively enabled features
+                .Single(g => g.Name == FeatureGroup.PublicGroupName);
+        }
+
+        protected User GetOrCreateUser(string userId)
+        {
+            var user = _db.Users
+                .Include(nameof(User.FeatureGroup))
+                .FirstOrDefault(u => u.Id == userId);
+
+            if (user != null)
+                return user;
+
+            // create new user
+            var newUser = CreateUser(userId);
+            _db.SaveChanges();
+            return newUser;
+        }
+
+        protected IEnumerable<User> GetOrCreateUsers(IEnumerable<string> userIds)
+        {
+            if (userIds == null)
+                return _noUsers;
+
+            var userIdsSet = userIds.ToSet();
+            var storedUsers = _db.Users.Where(u => userIdsSet.Contains(u.Id)).ToList();
+            var missingUserIds = userIdsSet.Except(storedUsers.Select(u => u.Id));
+
+            if (missingUserIds.Any())
+            {
+                // Create missing users
+                var newUsers = missingUserIds.Select(id => CreateUser(id)).ToList();
+                _db.SaveChanges();
+                return storedUsers.Concat(newUsers);
+            }
+
+            return storedUsers;
+        }
+
+        public IQueryable<FeatureGroup> GetAllGroups(bool loadMembers = false, bool loadFeatures = false)
+        {
+            return _db.FeatureGroups
+                .IncludeIf(loadMembers, nameof(FeatureGroup.Members))
+                .IncludeIf(loadFeatures, nameof(FeatureGroup.EnabledFeatures));
+        }
+
+        public FeatureGroup GetGroup(int groupId, bool loadMembers = false, bool loadFeatures = false)
+        {
+            return GetAllGroups(loadMembers, loadFeatures)
+                .FirstOrDefault(g => g.Id == groupId);
+        }
+        
+        /// <exception cref="ResourceNotFoundException{Feature}">No features exist for one or multiple of the specified IDs</exception>
+        protected IReadOnlyCollection<Feature> GetFeatures(IEnumerable<int> featureIds, bool loadGroups = false)
+        {
+            if (featureIds == null)
+                return _noFeatures;
+
+            var featureIdsSet = featureIds.ToSet();
+
+            var storedFeatures = _db.Features
+                .IncludeIf(loadGroups, nameof(Feature.GroupsWhereEnabled))
+                .Where(f => featureIdsSet.Contains(f.Id)).ToList();
+
+            var missingFeatureIds = featureIdsSet.Except(storedFeatures.Select(f => f.Id));
+
+            if (missingFeatureIds.Any())
+                throw new ResourceNotFoundException<Feature>(missingFeatureIds);
+
+            return storedFeatures;
+        }
+
+        public IQueryable<Feature> GetAllFeatures(bool loadParent = false, bool loadChildren = false, bool loadGroups = false)
+        {
+            return _db.Features
+                .IncludeIf(loadParent, nameof(Feature.Parent))
+                .IncludeIf(loadChildren, nameof(Feature.Children))
+                .IncludeIf(loadGroups, nameof(Feature.GroupsWhereEnabled));
+        }
+
+        public Feature GetFeature(int featureId, bool loadParent = false, bool loadChildren = false, bool loadGroups = false)
+        {
+            return GetAllFeatures(loadParent, loadChildren, loadGroups)
+                .FirstOrDefault(f => f.Id == featureId);
+        }
+
+        private User CreateUser(string id)
+        {
+            var user = new User
+            {
+                Id = id,
+                FeatureGroup = DefaultGroup
+            };
+
+            _db.Users.Add(user);
+            return user;
+        }
+    }
+}

--- a/HiP-FeatureToggle/Managers/FeatureTogglesManagerBase.cs
+++ b/HiP-FeatureToggle/Managers/FeatureTogglesManagerBase.cs
@@ -30,11 +30,15 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
             // Load standard groups which are always available and can't be deleted.
             // If this fails, the database is not correctly initialized.
             DefaultGroup = GetAllGroups(true, true)
-                .Include(g => g.EnabledFeatures).ThenInclude(m => m.Feature)
+                .Include(g => g.EnabledFeatures)
+                    .ThenInclude(m => m.Feature) // loading this is required for checking effectively enabled features
+                        .ThenInclude(f => f.Children)
                 .Single(g => g.Name == FeatureGroup.DefaultGroupName);
 
             PublicGroup = GetAllGroups(true, true)
-                .Include(g => g.EnabledFeatures).ThenInclude(m => m.Feature) // loading this is required for checking effectively enabled features
+                .Include(g => g.EnabledFeatures)
+                    .ThenInclude(m => m.Feature) // loading this is required for checking effectively enabled features
+                        .ThenInclude(f => f.Children)
                 .Single(g => g.Name == FeatureGroup.PublicGroupName);
         }
 

--- a/HiP-FeatureToggle/Managers/FeaturesManager.cs
+++ b/HiP-FeatureToggle/Managers/FeaturesManager.cs
@@ -1,32 +1,17 @@
-﻿using PaderbornUniversity.SILab.Hip.FeatureToggle.Data;
+﻿using Microsoft.EntityFrameworkCore;
+using PaderbornUniversity.SILab.Hip.FeatureToggle.Data;
 using PaderbornUniversity.SILab.Hip.FeatureToggle.Models.Entity;
 using PaderbornUniversity.SILab.Hip.FeatureToggle.Models.Rest;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
 {
-    public class FeaturesManager
+    public class FeaturesManager : FeatureTogglesManagerBase
     {
-        private readonly ToggleDbContext _db;
-
-        public FeaturesManager(ToggleDbContext db)
+        public FeaturesManager(ToggleDbContext db) : base(db)
         {
-            _db = db;
-        }
-
-        public IQueryable<Feature> GetFeatures(bool loadParent = false, bool loadChildren = false, bool loadGroups = false)
-        {
-            return _db.Features
-                .IncludeIf(loadParent, nameof(Feature.Parent))
-                .IncludeIf(loadChildren, nameof(Feature.Children))
-                .IncludeIf(loadGroups, nameof(Feature.GroupsWhereEnabled));
-        }
-
-        public Feature GetFeature(int featureId, bool loadParent = false, bool loadChildren = false, bool loadGroups = false)
-        {
-            return GetFeatures(loadParent, loadChildren, loadGroups)
-                .FirstOrDefault(f => f.Id == featureId);
         }
 
         /// <exception cref="ArgumentNullException">The specified arguments are null</exception>
@@ -142,22 +127,110 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
             _db.SaveChanges();
         }
 
+        /// <summary>
+        /// Checks whether a specific feature is effectively enabled for a specific user or an anonymous
+        /// (unauthenticated) user. Anonymous users are considered to be in the
+        /// <see cref="FeatureTogglesManagerBase.PublicGroup"/>.
+        /// </summary>
+        /// <exception cref="ResourceNotFoundException{Feature}"/>
+        public bool IsFeatureEffectivelyEnabledForUser(string userId, int featureId)
+        {
+            var group = GetGroupForUser(userId);
+            var feature = GetFeature(featureId);
+
+            if (feature == null)
+                throw new ResourceNotFoundException<Feature>(featureId);
+
+            return IsFeatureEffectivelyEnabledForGroup(feature, group);
+        }
+
+        /// <summary>
+        /// Gets the features that are effectively enabled for a specific user or an anonymous (unauthenticated) user.
+        /// Anonymous users are considered to be in the <see cref="FeatureTogglesManagerBase.PublicGroup"/>.
+        /// </summary>
+        /// <param name="userId">The ID of a user or null for anonymous users</param>
+        /// <returns></returns>
+        public IReadOnlyCollection<Feature> GetEffectivelyEnabledFeaturesForUser(string userId)
+        {
+            var group = GetGroupForUser(userId);
+            return GetEffectivelyEnabledFeaturesForGroup(group);
+        }
+
+        private FeatureGroup GetGroupForUser(string userId)
+        {
+            // for anonymous users, the protected public group is relevant
+            if (userId == null)
+                return PublicGroup;
+
+            // for authenticated users, it is the group they are assigned to
+            var user = GetOrCreateUser(userId);
+
+            return _db.FeatureGroups
+                .Include(g => g.EnabledFeatures).ThenInclude(m => m.Feature)
+                .First(g => g.Id == user.FeatureGroupId); // per specification, this group must exist
+        }
+
+        private bool IsFeatureEffectivelyEnabledForGroup(Feature feature, FeatureGroup group)
+        {
+            // required navigation properties: FeatureGroup.EnabledFeatures
+            var enabledFeatures = group.EnabledFeatures
+                .Concat(PublicGroup.EnabledFeatures)
+                .Distinct();
+
+            return AncestorsAndSelf(feature).All(parent => enabledFeatures.Any(m => m.FeatureId == parent.Id));
+        }
+
+        private IReadOnlyCollection<Feature> GetEffectivelyEnabledFeaturesForGroup(FeatureGroup group)
+        {
+            // required navigation properties: FeatureGroup.EnabledFeatures.Feature
+
+            // The feature group specifies which features are enabled.
+            // From specification: "A feature X is [effectively] enabled for a certain user if X and all features
+            // higher than X in the feature hierarchy are enabled for the user's feature group [or the public group]"
+            // (features enabled in the public group are "added" to those of the user's group, HIPCMS-608)
+            // Thus, the set of effectively enabled features is a subset of the enabled features.
+
+            // Example:
+            // Feature Hierarchy:        Features enabled in user Bob's group: [1, 2, 4]
+            // (1)                       Features enabled in public group:     [3, 5]
+            //    (2)
+            // (3)                       Features effectively enabled for user Bob:        [1, 3, 5]
+            //    (4)                    Features effectively enabled for unauthenticated users: [3]
+            //       (5)
+            //       (6)
+            //    (7)
+
+            var enabledFeatures = group.EnabledFeatures
+                .Concat(PublicGroup.EnabledFeatures)
+                .Distinct()
+                .Select(m => m.Feature)
+                .ToSet();
+
+            return enabledFeatures
+                .Where(f => AncestorsAndSelf(f).All(parent => enabledFeatures.Contains(parent)))
+                .ToList();
+        }
+
         private bool IsDescendantOrEqual(Feature feature, Feature other)
         {
             // checks if 'feature' is a descendant of 'other' in the feature tree structure
             // or if 'feature' and 'other' are the same.
+            return feature != null && other != null && AncestorsAndSelf(feature).Contains(other);
+        }
+
+        private IEnumerable<Feature> AncestorsAndSelf(Feature feature)
+        {
+            // returns a collection of the feature itself, its parent, its parent's parent etc. (up to the root)
             // (potentially expensive operation, depending on the tree depth)
 
-            if (feature == null || other == null)
-                return false;
+            while (feature != null)
+            {
+                yield return feature;
 
-            if (feature == other)
-                return true;
-
-            // next parent must be explicitly loaded since usually not the whole tree structure is available here
-            // (Note: Load() doesn't work here, probably because the entity is tracked)
-            var next = _db.Entry(feature).Reference(f => f.Parent).Query().FirstOrDefault();
-            return IsDescendantOrEqual(next, other);
+                // next parent must be explicitly loaded since usually not the whole tree structure is available here
+                // (Note: Load() doesn't work here, probably because the entity is tracked)
+                feature = _db.Entry(feature).Reference(f => f.Parent).Query().FirstOrDefault();
+            }
         }
     }
 }

--- a/HiP-FeatureToggle/Managers/FeaturesManager.cs
+++ b/HiP-FeatureToggle/Managers/FeaturesManager.cs
@@ -166,7 +166,7 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Managers
             var user = GetOrCreateUser(userId);
 
             return _db.FeatureGroups
-                .Include(g => g.EnabledFeatures).ThenInclude(m => m.Feature)
+                .Include(g => g.EnabledFeatures).ThenInclude(m => m.Feature).ThenInclude(f => f.Children)
                 .First(g => g.Id == user.FeatureGroupId); // per specification, this group must exist
         }
 

--- a/HiP-FeatureToggle/Models/Entity/User.cs
+++ b/HiP-FeatureToggle/Models/Entity/User.cs
@@ -5,5 +5,7 @@
         public string Id { get; set; }
 
         public FeatureGroup FeatureGroup { get; set; }
+
+        public int FeatureGroupId { get; set; }
     }
 }

--- a/HiP-FeatureToggle/Models/Rest/FeatureResult.cs
+++ b/HiP-FeatureToggle/Models/Rest/FeatureResult.cs
@@ -1,4 +1,5 @@
-﻿using PaderbornUniversity.SILab.Hip.FeatureToggle.Models.Entity;
+﻿using Newtonsoft.Json;
+using PaderbornUniversity.SILab.Hip.FeatureToggle.Models.Entity;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -12,8 +13,10 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle.Models.Rest
 
         public int? Parent { get; }
 
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public IReadOnlyCollection<int> Children { get; }
 
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public IReadOnlyCollection<int> GroupsWhereEnabled { get; }
 
         public FeatureResult(Feature feature)

--- a/HiP-FeatureToggle/Startup.cs
+++ b/HiP-FeatureToggle/Startup.cs
@@ -55,7 +55,7 @@ namespace PaderbornUniversity.SILab.Hip.FeatureToggle
             {
                 // Define a Swagger document
                 c.SwaggerDoc("v1", new Info() { Title = _Name, Version = _Version });
-                c.OperationFilter<SwaggerOperationFilter>();
+                c.OperationFilter<CustomSwaggerOperationFilter>();
             });
 
             // Add framework services.


### PR DESCRIPTION
Critical things to check:
* If the feature hierarchy is A with child B with child C, and only A and C are enabled in the user's group, does GET /Api/Features/IsEnabled only return A? (it should)
* Are the enabled features from both, the user's assigned group and the public group, correctly combined?
  * e.g. if, in addition, feature B is enabled in the public group, does GET /Api/Features/IsEnabled then return A, B and C? (it should)

This PR also solves [HIPCMS-608](https://atlassian-hip.cs.uni-paderborn.de/jira/browse/HIPCMS-608). Things to check here:
* Is it somehow possible to assign members to the public group? (it should not)